### PR TITLE
Use the gcr.io registry for base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:latest
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:latest
 
 ENV GOOGLE_PROJECT fake-project
 ENV DATASTORE_CONSISTENCY 0.9


### PR DESCRIPTION
Builds on this repo started failing with permission denied errors pulling the image from Docker Hub. The image is built by google and also available via gcr.io. This just updates the base image in the Dockerfile to use the image in gcr.io